### PR TITLE
Support parallelism (multi-process) and optimize flow

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,2 +1,4 @@
 from .manifest_creator import ImageManifestCreator
 from .registry import Registry
+from .extractor import Extractor
+from .processor import Processor

--- a/core/extractor.py
+++ b/core/extractor.py
@@ -1,0 +1,56 @@
+import os
+import tarfile
+import json
+import time
+
+import humanfriendly
+
+
+class Extractor(object):
+    def __init__(self, logger, archive_path):
+        self._logger = logger.get_child('tar')
+        self._archive_path = os.path.abspath(archive_path)
+
+        self._logger.debug(
+            'Initialized',
+            archive_path=self._archive_path,
+        )
+
+    @property
+    def archive_path(self):
+        return self._archive_path
+
+    def get_config(self, name):
+        return self._extract_json_from_tar(self._archive_path, name)
+
+    def extract_all(self, target_dir):
+        self._logger.info(
+            'Extracting', archive_path=self._archive_path, target_dir=target_dir
+        )
+        start_time = time.time()
+        with tarfile.open(self._archive_path) as fh:
+            fh.extractall(target_dir)
+        elapsed = time.time() - start_time
+        self._logger.info(
+            'Archive extracted',
+            archive_path=self._archive_path,
+            target_dir=target_dir,
+            elapsed=humanfriendly.format_timespan(elapsed),
+        )
+
+    def _extract_json_from_tar(self, tar_filepath, file_to_parse):
+        loaded = self._extract_file_from_tar(tar_filepath, file_to_parse)
+        stringified = self._parse_as_utf8(loaded)
+        return json.loads(stringified)
+
+    @staticmethod
+    def _extract_file_from_tar(tar_filepath, file_to_extract):
+        tarfile_obj = tarfile.open(tar_filepath)
+        file_contents = tarfile_obj.extractfile(file_to_extract)
+        return file_contents
+
+    @staticmethod
+    def _parse_as_utf8(to_parse):
+        as_str = (to_parse.read()).decode("utf-8")
+        to_parse.close()
+        return as_str

--- a/core/processor.py
+++ b/core/processor.py
@@ -75,12 +75,12 @@ class Processor(object):
 
                 pool.close()
                 pool.join()
-        elapsed = time.time() - start_time
 
         # this will throw if any pool worker caught an exception
         for res in results:
             res.get()
 
+        elapsed = time.time() - start_time
         self._logger.info(
             'Finished processing archive',
             archive_path=self._extractor.archive_path,

--- a/core/processor.py
+++ b/core/processor.py
@@ -87,7 +87,6 @@ def process_archive(logger, _extractor, _registry, parallel):
 
     logger.info(
         'Finished processing archive',
-        results=[res.get() for res in results],
         archive_path=_extractor.archive_path,
         elapsed=humanfriendly.format_timespan(elapsed),
     )

--- a/core/processor.py
+++ b/core/processor.py
@@ -1,0 +1,106 @@
+import tempfile
+import multiprocessing.pool
+import time
+import os.path
+import json
+
+import humanfriendly
+
+from . import registry
+from . import extractor
+
+
+class Processor(object):
+    def __init__(
+        self,
+        logger,
+        parallel,
+        registry_url,
+        archive_path,
+        stream=False,
+        login=None,
+        password=None,
+        ssl_verify=True,
+        replace_tags_match=None,
+        replace_tags_target=None,
+    ):
+        self._logger = logger
+        self._parallel = parallel
+
+        if parallel > 1 and stream:
+            self._logger.info(
+                'Stream output requested in conjunction with parallel operation. '
+                'This will mangle output, disabling stream output'
+            )
+            stream = False
+
+        self._registry = registry.Registry(
+            logger=self._logger,
+            registry_url=registry_url,
+            stream=stream,
+            login=login,
+            password=password,
+            ssl_verify=ssl_verify,
+            replace_tags_match=replace_tags_match,
+            replace_tags_target=replace_tags_target,
+        )
+        self._extractor = extractor.Extractor(self._logger, archive_path)
+        self._parallel = parallel
+
+    def process(self):
+        process_archive(self._logger, self._extractor, self._registry, self._parallel)
+
+
+#
+# Global wrappers to use multiprocessing.pool.Pool which can't pickle instance methods
+#
+def process_archive(logger, _extractor, _registry, parallel):
+    """
+    Processing given archive and pushes the images it contains to the registry
+    """
+    start_time = time.time()
+    logger.info('Processing archive', archive_path=_extractor.archive_path)
+    results = []
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+
+        # extract the whole thing
+        _extractor.extract_all(tmp_dir_name)
+
+        manifest = get_manifest(tmp_dir_name)
+        logger.debug('Extracted archive manifest', manifest=manifest)
+
+        # prepare proc pool, note tarfile is not thread safe https://bugs.python.org/issue23649
+        with multiprocessing.pool.Pool(processes=parallel) as pool:
+            for image_config in manifest:
+                res = pool.apply_async(
+                    process_image, (logger, _registry, tmp_dir_name, image_config)
+                )
+                results.append(res)
+
+            pool.close()
+            pool.join()
+    elapsed = time.time() - start_time
+
+    # this will throw if any pool worker caught an exception
+    for res in results:
+        res.get()
+
+    logger.info(
+        'Finished processing archive',
+        results=[res.get() for res in results],
+        archive_path=_extractor.archive_path,
+        elapsed=humanfriendly.format_timespan(elapsed),
+    )
+
+
+def process_image(logger, _registry, tmp_dir_name, image_config):
+    try:
+        _registry.process_image(tmp_dir_name, image_config)
+    except Exception as exc:
+        logger.log_and_raise('error', 'Failed processing image', exc=exc)
+
+
+def get_manifest(tmp_dir_name):
+    with open(os.path.join(tmp_dir_name, 'manifest.json'), 'r') as fh:
+        manifest = json.loads(fh.read())
+        return manifest

--- a/core/registry.py
+++ b/core/registry.py
@@ -74,7 +74,7 @@ class Registry(object):
 
         for image_config in archive_manifest:
             self._process_pool.apply_async(self._process_image, image_config)
-            self._process_image(image_config)
+
         self._process_pool.close()
         self._process_pool.join()
         elapsed = (time.time() - start_time)
@@ -184,16 +184,21 @@ class Registry(object):
             "Content-Type": "application/vnd.docker.distribution.manifest.v2+json"
         }
         url = self._registry_url + "/v2/" + image + "/manifests/" + tag
-        r = requests.put(
+        response = requests.put(
             url,
             headers=headers,
             data=manifest,
             auth=self._basicauth,
             verify=self._ssl_verify,
         )
-        if r.status_code != 201:
+        if response.status_code != 201:
             self._logger.log_and_raise(
-                'error', 'Failed to push manifest', image=image, tag=tag
+                'error',
+                'Failed to push manifest',
+                image=image,
+                tag=tag,
+                status_code=response.status_code,
+                content=response.content,
             )
 
     def _initialize_push(self, repository):

--- a/dockerregistrypusher.py
+++ b/dockerregistrypusher.py
@@ -28,6 +28,7 @@ def run(args):
     # start root logger with kwargs and create manof
     reg_client = core.Registry(
         logger=logger,
+        parallel=args.parallel,
         archive_path=args.archive_path,
         registry_url=args.registry_url,
         stream=args.stream,
@@ -45,15 +46,25 @@ def run(args):
 
 
 def register_arguments(parser):
-    # global options for manof
+
+    # logger options
     clients.logging.Client.register_arguments(parser)
 
     # verbosity shorthands
     parser.add_argument(
         '-v',
+        '-verbose',
         help='Set log level to debug (same as --log-severity=debug)',
         action='store_true',
         default=False,
+    )
+
+    parser.add_argument(
+        '-p',
+        '--parallel',
+        help='Control parallelism (multi-processing)',
+        type=int,
+        default=1,
     )
 
     parser.add_argument(
@@ -70,14 +81,12 @@ def register_arguments(parser):
         help='The url of the target registry to push to',
     )
     parser.add_argument(
-        '-l',
         '--login',
         help='Basic-auth login name for registry',
         required=False,
     )
 
     parser.add_argument(
-        '-p',
         '--password',
         help='Basic-auth login password for registry',
         required=False,
@@ -113,16 +122,12 @@ def register_arguments(parser):
 
 
 if __name__ == '__main__':
-    # create an argument parser
     arg_parser = argparse.ArgumentParser()
 
-    # register all arguments and sub-commands
     register_arguments(arg_parser)
 
     parsed_args = arg_parser.parse_args()
 
-    # parse the known args, seeing how the targets may add arguments of their own and re-parse
     ret_val = run(parsed_args)
 
-    # return value
     sys.exit(ret_val)

--- a/dockerregistrypusher.py
+++ b/dockerregistrypusher.py
@@ -25,12 +25,12 @@ def run(args):
         log_colors=args.log_colors,
     ).logger
 
-    # start root logger with kwargs and create manof
-    reg_client = core.Registry(
+    # initialize and start processing
+    processor = core.Processor(
         logger=logger,
         parallel=args.parallel,
-        archive_path=args.archive_path,
         registry_url=args.registry_url,
+        archive_path=args.archive_path,
         stream=args.stream,
         login=args.login,
         password=args.password,
@@ -38,7 +38,8 @@ def run(args):
         replace_tags_match=args.replace_tags_match,
         replace_tags_target=args.replace_tags_target,
     )
-    reg_client.process_archive()
+    processor.process()
+
     if logger.first_error is None:
         retval = 0
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,3 +4,4 @@ simplejson==3.8.2
 colorama==0.4.4
 pygments==2.2.0
 incremental==17.5.0
+humanfriendly==4.8


### PR DESCRIPTION
- Restructure to support process pool work
- Since `tarfile` package is not threadsafe, parallelism is supported via multi processing.
- Controlled using `--parallel=X` (with default (1)), a process pool of the appropriate size will be used
- Significantly decreased runtime by isolating redundant extraction of the entire archive - now only happens once globally