### PR TITLE
Support gzipping layers (pre-processing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ ENV/
 # pycharm proj
 .idea
 
-# stray tar.gz files used for manual testing
+# stray archive files used for manual testing
+*.tar
 *.tar.gz

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,4 +1,4 @@
-from .manifest_creator import ImageManifestCreator
+from .image_manifest_creator import ImageManifestCreator
 from .registry import Registry
 from .extractor import Extractor
 from .processor import Processor

--- a/core/image_manifest_creator.py
+++ b/core/image_manifest_creator.py
@@ -5,7 +5,9 @@ import utils.helpers
 
 
 class ImageManifestCreator(object):
-    def __init__(self, config_path, layers_info, config_info):
+    def __init__(self, name, tag, config_path, layers_info, config_info):
+        self._name = name
+        self._tag = tag
         self._config_path = config_path
         self._layers_info = layers_info
         self._config_info = config_info

--- a/core/image_manifest_creator.py
+++ b/core/image_manifest_creator.py
@@ -20,8 +20,12 @@ class ImageManifestCreator(object):
         }
         manifest["layers"] = []
         for layer_info in self._layers_info:
+            if layer_info['ext'].endswith('gz'):
+                media_type = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+            else:
+                media_type = "application/vnd.docker.image.rootfs.diff.tar"
             layer_data = {
-                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                "mediaType": media_type,
                 "size": layer_info['size'],
                 "digest": layer_info['digest'],
             }

--- a/core/image_manifest_creator.py
+++ b/core/image_manifest_creator.py
@@ -5,9 +5,10 @@ import utils.helpers
 
 
 class ImageManifestCreator(object):
-    def __init__(self, config_path, layers_info):
+    def __init__(self, config_path, layers_info, config_info):
         self._config_path = config_path
         self._layers_info = layers_info
+        self._config_info = config_info
 
     def create(self):
         manifest = dict()
@@ -15,12 +16,12 @@ class ImageManifestCreator(object):
         manifest["mediaType"] = "application/vnd.docker.distribution.manifest.v2+json"
         manifest["config"] = {
             "mediaType": "application/vnd.docker.container.image.v1+json",
-            "size": os.path.getsize(self._config_path),
-            "digest": utils.helpers.get_digest(self._config_path),
+            "size": self._config_info['size'],
+            "digest": self._config_info['digest'],
         }
         manifest["layers"] = []
         for layer_info in self._layers_info:
-            if layer_info['ext'].endswith('gz'):
+            if layer_info['ext'].endswith('gz') or layer_info['ext'].endswith('gzip'):
                 media_type = "application/vnd.docker.image.rootfs.diff.tar.gzip"
             else:
                 media_type = "application/vnd.docker.image.rootfs.diff.tar"

--- a/core/manifest_creator.py
+++ b/core/manifest_creator.py
@@ -21,7 +21,7 @@ class ImageManifestCreator(object):
         manifest["layers"] = []
         for layer in self._layers_paths:
             layer_data = dict()
-            layer_data["mediaType"] = "application/vnd.docker.image.rootfs.diff.tar"
+            layer_data["mediaType"] = "application/vnd.docker.image.rootfs.diff.tar.gzip"
             layer_data["size"] = os.path.getsize(layer)
             layer_data["digest"] = self._get_digest(layer)
             manifest["layers"].append(layer_data)

--- a/core/manifest_creator.py
+++ b/core/manifest_creator.py
@@ -1,6 +1,7 @@
 import os
-import hashlib
 import json
+
+import utils.helpers
 
 
 class ImageManifestCreator(object):
@@ -15,7 +16,7 @@ class ImageManifestCreator(object):
         manifest["config"] = {
             "mediaType": "application/vnd.docker.container.image.v1+json",
             "size": os.path.getsize(self._config_path),
-            "digest": self._get_digest(self._config_path),
+            "digest": utils.helpers.get_digest(self._config_path),
         }
         manifest["layers"] = []
         for layer_info in self._layers_info:
@@ -27,17 +28,3 @@ class ImageManifestCreator(object):
             manifest["layers"].append(layer_data)
 
         return json.dumps(manifest)
-
-    def _get_digest(self, filepath):
-        return "sha256:" + self.get_file_sha256(filepath)
-
-    @staticmethod
-    def get_file_sha256(filepath):
-        sha256hash = hashlib.sha256()
-        with open(filepath, "rb") as f:
-            while True:
-                data = f.read(65536)
-                sha256hash.update(data)
-                if not data:
-                    break
-        return sha256hash.hexdigest()

--- a/core/manifest_creator.py
+++ b/core/manifest_creator.py
@@ -12,18 +12,18 @@ class ImageManifestCreator(object):
         manifest = dict()
         manifest["schemaVersion"] = 2
         manifest["mediaType"] = "application/vnd.docker.distribution.manifest.v2+json"
-        manifest["config"] = dict()
-        manifest["config"][
-            "mediaType"
-        ] = "application/vnd.docker.container.image.v1+json"
-        manifest["config"]["size"] = os.path.getsize(self._config_path)
-        manifest["config"]["digest"] = self._get_digest(self._config_path)
+        manifest["config"] = {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": os.path.getsize(self._config_path),
+            "digest": self._get_digest(self._config_path),
+        }
         manifest["layers"] = []
         for layer in self._layers_paths:
-            layer_data = dict()
-            layer_data["mediaType"] = "application/vnd.docker.image.rootfs.diff.tar.gzip"
-            layer_data["size"] = os.path.getsize(layer)
-            layer_data["digest"] = self._get_digest(layer)
+            layer_data = {
+                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                "size": os.path.getsize(layer),
+                "digest": self._get_digest(layer),
+            }
             manifest["layers"].append(layer_data)
 
         return json.dumps(manifest)

--- a/core/manifest_creator.py
+++ b/core/manifest_creator.py
@@ -4,9 +4,9 @@ import json
 
 
 class ImageManifestCreator(object):
-    def __init__(self, config_path, layers_paths):
+    def __init__(self, config_path, layers_info):
         self._config_path = config_path
-        self._layers_paths = layers_paths
+        self._layers_info = layers_info
 
     def create(self):
         manifest = dict()
@@ -18,11 +18,11 @@ class ImageManifestCreator(object):
             "digest": self._get_digest(self._config_path),
         }
         manifest["layers"] = []
-        for layer in self._layers_paths:
+        for layer_info in self._layers_info:
             layer_data = {
                 "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-                "size": os.path.getsize(layer),
-                "digest": self._get_digest(layer),
+                "size": layer_info['size'],
+                "digest": layer_info['digest'],
             }
             manifest["layers"].append(layer_data)
 

--- a/core/processor.py
+++ b/core/processor.py
@@ -72,7 +72,7 @@ class Processor(object):
             self._extractor.extract_all(tmp_dir_name)
 
             # compress layers in place - for kaniko
-            self._compress_layer_files(tmp_dir_name)
+            # self._compress_layer_files(tmp_dir_name)
 
             manifest = self._get_manifest(tmp_dir_name)
             self._logger.debug('Extracted archive manifest', manifest=manifest)

--- a/core/processor.py
+++ b/core/processor.py
@@ -195,7 +195,7 @@ class Processor(object):
                     image_config["Layers"][idx] = layer + '.gz'
 
         # write modified image config
-        self._write_manifest(root_dir)
+        self._write_manifest(root_dir, manifest)
 
         elapsed = time.time() - start_time
         self._logger.info(

--- a/core/processor.py
+++ b/core/processor.py
@@ -109,6 +109,7 @@ class Processor(object):
                 res.get()
         finally:
             shutil.rmtree(tmp_dir_name)
+            self._logger.verbose('Removed workdir', tmp_dir_name=tmp_dir_name)
 
         elapsed = time.time() - start_time
         self._logger.info(

--- a/core/processor.py
+++ b/core/processor.py
@@ -199,7 +199,8 @@ class Processor(object):
 
         elapsed = time.time() - start_time
         self._logger.info(
-            'Finished compressing all layer files (pre-processing)', elapsed=elapsed
+            'Finished compressing all layer files (pre-processing)',
+            elapsed=humanfriendly.format_timespan(elapsed)
         )
 
     @staticmethod

--- a/core/processor.py
+++ b/core/processor.py
@@ -146,9 +146,9 @@ class Processor(object):
                 if not os.path.islink(path):
                     continue
 
-                target_path = os.readlink(path)
+                target_path = str(os.readlink(path))
 
-                if str(target_path).endswith('layer.tar'):
+                if target_path.endswith('layer.tar'):
                     self._logger.debug(
                         'Found link to tar layer, pointing to compressed',
                         target_path=target_path,
@@ -156,7 +156,7 @@ class Processor(object):
                     )
 
                     # try and fix - point to tar.gz
-                    new_target_path = target_path + bytes(gzip_ext)
+                    new_target_path = target_path + gzip_ext
                     tmp_link_path = f'{target_path}_tmplink'
                     os.symlink(new_target_path, tmp_link_path)
                     os.unlink(path)

--- a/core/processor.py
+++ b/core/processor.py
@@ -108,8 +108,7 @@ class Processor(object):
             for res in results:
                 res.get()
         finally:
-            # shutil.rmtree(tmp_dir_name)
-            pass
+            shutil.rmtree(tmp_dir_name)
 
         elapsed = time.time() - start_time
         self._logger.info(

--- a/core/processor.py
+++ b/core/processor.py
@@ -148,7 +148,7 @@ class Processor(object):
 
                 target_path = os.readlink(path)
 
-                if target_path.endswith(b'layer.tar'):
+                if str(target_path).endswith('layer.tar'):
                     self._logger.debug(
                         'Found link to tar layer, pointing to compressed',
                         target_path=target_path,

--- a/core/processor.py
+++ b/core/processor.py
@@ -157,7 +157,7 @@ class Processor(object):
 
                     # try and fix - point to tar.gz
                     new_target_path = target_path + gzip_ext
-                    tmp_link_path = f'{target_path}_tmplink'
+                    tmp_link_path = f'{path}_tmplink'
                     os.symlink(new_target_path, tmp_link_path)
                     os.unlink(path)
                     os.rename(tmp_link_path, path)

--- a/core/processor.py
+++ b/core/processor.py
@@ -200,7 +200,7 @@ class Processor(object):
         elapsed = time.time() - start_time
         self._logger.info(
             'Finished compressing all layer files (pre-processing)',
-            elapsed=humanfriendly.format_timespan(elapsed)
+            elapsed=humanfriendly.format_timespan(elapsed),
         )
 
     @staticmethod

--- a/core/processor.py
+++ b/core/processor.py
@@ -2,12 +2,16 @@ import tempfile
 import multiprocessing.pool
 import time
 import os.path
+import pathlib
 import json
+import subprocess
+import shlex
 
 import humanfriendly
 
 from . import registry
 from . import extractor
+import utils.helpers
 
 
 class Processor(object):
@@ -67,6 +71,9 @@ class Processor(object):
             # extract the whole thing
             self._extractor.extract_all(tmp_dir_name)
 
+            # compress layers in place - for kaniko
+            self._compress_layer_files(tmp_dir_name)
+
             manifest = self._get_manifest(tmp_dir_name)
             self._logger.debug('Extracted archive manifest', manifest=manifest)
 
@@ -94,11 +101,117 @@ class Processor(object):
             elapsed=humanfriendly.format_timespan(elapsed),
         )
 
+    def _compress_layer_files(self, root_dir):
+        start_time = time.time()
+
+        # for Kaniko compatibility - must be real tar.gzip and not just tar
+        self._logger.info('Compressing all layer files (pre-processing)')
+        for tar_files in pathlib.Path(root_dir).rglob('*.tar'):
+            file_path = tar_files.absolute()
+            self._logger.info('Compressing file (.tar -> .tar.gz)', file_path=file_path)
+
+            # safety - if .tar.gz is in place, skip
+            # compression and ignore the original
+            if os.path.exists(str(file_path) + '.gz'):
+                self._logger.debug(
+                    'Layer file is gzipped - skipping',
+                    file_path=file_path,
+                    gzipped_path=str(file_path) + '.gz',
+                )
+                continue
+
+            # use -f to avoid "Too many levels of symbolic links" failures
+            try:
+                # use -f to avoid "Too many levels of symbolic links" failures
+                gzip_cmd = shlex.split(f'gzip -9 -f {file_path}')
+                out = subprocess.check_output(gzip_cmd, encoding='utf-8')
+                self._logger.debug(
+                    'Successfully gzipped layer',
+                    gzip_cmd=gzip_cmd,
+                    out=out,
+                    file_path=file_path,
+                )
+
+            # catch and print for debugging
+            except Exception as exc:
+                cmd = shlex.split(f'ls -latr {os.path.dirname(file_path)}')
+                out = subprocess.check_output(cmd, encoding='utf-8')
+                self._logger.warn(
+                    'Finished ls command',
+                    cmd=cmd,
+                    out=out,
+                    orig_exc=exc,
+                )
+                raise
+
+        # fix symlinks
+        for root, dirs, files in os.walk(root_dir):
+            for filename in files:
+                path = os.path.join(root, filename)
+
+                # If it's not a symlink we're not interested.
+                if not os.path.islink(path):
+                    continue
+
+                target_path = os.readlink(path)
+
+                if not os.path.exists(target_path):
+                    self._logger.debug(
+                        'Found broken link', target_path=target_path, path=path
+                    )
+
+                    # try and fix - point to tar.gz
+                    new_target_path = target_path + b'.gz'
+                    if os.path.exists(new_target_path):
+                        tmp_link_path = f'{target_path}_tmplink'
+                        os.symlink(new_target_path, tmp_link_path)
+                        os.unlink(path)
+                        os.rename(tmp_link_path, path)
+                        self._logger.debug(
+                            'Fixed broken link',
+                            new_target_path=new_target_path,
+                            path=path,
+                        )
+                    else:
+                        self._logger.log_and_raise(
+                            'error',
+                            'Cannot fix broken link',
+                            target_path=target_path,
+                            path=path,
+                        )
+        self._logger.debug('Correcting image manifests')
+        manifest = self._get_manifest(root_dir)
+        for image_config in manifest:
+            config_filename = image_config["Config"]
+
+            # rootfs.diff_ids contains layer digests - TODO change them?
+            config_path = os.path.join(root_dir, config_filename)
+            config_parsed = utils.helpers.load_json_file(config_path)
+
+            # warning - spammy
+            self._logger.verbose('Parsed image config', config_parsed=config_parsed)
+            for idx, layer in enumerate(image_config["Layers"]):
+                if layer.endswith('.tar'):
+                    image_config["Layers"][idx] = layer + '.gz'
+
+        # write modified image config
+        self._write_manifest(root_dir)
+
+        elapsed = time.time() - start_time
+        self._logger.info(
+            'Finished compressing all layer files (pre-processing)', elapsed=elapsed
+        )
+
     @staticmethod
-    def _get_manifest(tmp_dir_name):
-        with open(os.path.join(tmp_dir_name, 'manifest.json'), 'r') as fh:
+    def _get_manifest(archive_dir):
+        with open(os.path.join(archive_dir, 'manifest.json'), 'r') as fh:
             manifest = json.loads(fh.read())
             return manifest
+
+    @staticmethod
+    def _write_manifest(archive_dir, contents):
+        with open(os.path.join(archive_dir, 'manifest.json'), 'w') as fh:
+            json.dump(contents, fh)
 
 
 #

--- a/core/processor.py
+++ b/core/processor.py
@@ -140,7 +140,9 @@ class Processor(object):
                 # inplace .tar ->.tar.gz
                 self._logger.info('Compressing layer file', file_path=file_path)
 
-                with open(file_path, 'rb') as f_in, gzip.open(gzipped_file_path, 'wb') as f_out:
+                with open(file_path, 'rb') as f_in, gzip.open(
+                    gzipped_file_path, 'wb'
+                ) as f_out:
                     f_out.writelines(f_in)
 
                 self._logger.debug(
@@ -222,9 +224,14 @@ class Processor(object):
                 if layer.endswith('.tar'):
                     gzipped_layer_file_path = layer + '.gz'
                     manifest_image_section["Layers"][idx] = gzipped_layer_file_path
-                    image_config["rootfs"]['diff_ids'][idx] = \
-                        utils.helpers.get_digest(os.path.join(root_dir, gzipped_layer_file_path))
-            self._logger.debug('Corrected image config', config_path=config_path, image_config=image_config)
+                    image_config["rootfs"]['diff_ids'][idx] = utils.helpers.get_digest(
+                        os.path.join(root_dir, gzipped_layer_file_path)
+                    )
+            self._logger.debug(
+                'Corrected image config',
+                config_path=config_path,
+                image_config=image_config,
+            )
             utils.helpers.dump_json_file(config_path, image_config)
 
         # write modified image config

--- a/core/registry.py
+++ b/core/registry.py
@@ -211,17 +211,18 @@ class Registry(object):
         content_path = os.path.abspath(filepath)
 
         # for kaniko compatibility - must be real tar.gzip and not just tar
-        if gzip:
-            if os.path.splitext(filepath)[1] == '.tar':
-                new_content_path = content_path + '.gz'
-                self._logger.debug(
-                    'File is not gzipped - compressing before upload',
-                    content_path=content_path,
-                    new_content_path=new_content_path,
-                )
+        if gzip and os.path.splitext(filepath)[1] == '.tar':
+            new_content_path = content_path + '.gz'
+            self._logger.debug(
+                'File is not gzipped - compressing before upload',
+                content_path=content_path,
+                new_content_path=new_content_path,
+            )
 
-                subprocess.check_call(shlex.split(f'gzip -9 {content_path}'))
-                content_path = new_content_path
+            gzip_cmd = shlex.split(f'gzip -9 {content_path}')
+            out = subprocess.check_call(gzip_cmd)
+            self._logger.debug('Finished gzipping', gzip_cmd=gzip_cmd, out=out)
+            content_path = new_content_path
 
         total_size = os.stat(filepath).st_size
 

--- a/core/registry.py
+++ b/core/registry.py
@@ -186,13 +186,14 @@ class Registry:
         self._layers_lock.get_lock(layer_key).acquire()
         try:
 
-            if layer_key in self._layers_info:
-                layer_info = self._layers_info[layer_key]
-                self._logger.info(
-                    'Layer already pushed, skipping',
-                    layer_info=layer_info,
-                )
-                return layer_info['digest'], layer_info['size']
+            # if layer_key in self._layers_info:
+            #     layer_info = self._layers_info[layer_key]
+            #     self._logger.info(
+            #         'Layer already pushed, skipping',
+            #         layer_key=layer_key,
+            #         layer_info=layer_info,
+            #     )
+            #     return layer_info['digest'], layer_info['size']
 
             layer_path = os.path.abspath(os.path.join(tmp_dir_name, layer))
 
@@ -220,7 +221,7 @@ class Registry:
                                                    layer_path=layer_path,
                                                    image=image)
 
-                # safety - handle cases where some race of corruption may have occurred, if .tar.gz is in place, skip
+                # safety - handle cases where some race or corruption may have occurred, if .tar.gz is in place, skip
                 # compression and ignore the original
                 if not os.path.exists(layer_path + '.gz'):
                     self._logger.debug(

--- a/core/registry.py
+++ b/core/registry.py
@@ -95,7 +95,7 @@ class Registry:
                 tmp_dir_name=tmp_dir_name,
             )
 
-            # push individual image layers
+            # push image layer blobs
             layers = image_config["Layers"]
             manifest_layer_info = []
             for layer in layers:

--- a/core/registry.py
+++ b/core/registry.py
@@ -202,6 +202,7 @@ class Registry:
                 # handle symlinks
                 if os.path.islink(layer_path):
                     symlinked_path = os.path.realpath(layer_path)
+                    self._logger.debug('Found symlink layer', layer_path=layer_path, symlinked_path=symlinked_path)
 
                     # symlink target missing (probably compressed tar -> tar.gz)
                     compressed_symlinked_path = symlinked_path + '.gz'
@@ -210,6 +211,7 @@ class Registry:
                         # fix
                         tmp_link_path = f'{layer_path}_tmplink'
                         os.symlink(compressed_symlinked_path, tmp_link_path)
+                        os.unlink(layer_path)
                         os.rename(tmp_link_path, layer_path)
                     elif not os.path.exists(symlinked_path):
                         self._logger.log_and_raise('error',

--- a/core/registry.py
+++ b/core/registry.py
@@ -258,6 +258,7 @@ class Registry:
                 'digest': digest,
                 'size': size,
             }
+            self._logger.info('Layer pushed', layer=layer, digest=digest, size=size)
             return digest, size
         finally:
             self._logger.debug('Releasing layer lock', layer_key=layer_key)

--- a/core/registry.py
+++ b/core/registry.py
@@ -242,13 +242,13 @@ class Registry:
                 length_read += len(chunk)
                 offset = index + len(chunk)
 
-                headers['Content-Type'] = 'application/octet-stream'
-                headers['Content-Length'] = str(len(chunk))
-                headers['Content-Range'] = f'{index}-{offset}'
-
                 # compress
                 headers['content-encoding'] = 'gzip'
                 request_body = zlib.compress(chunk)
+
+                headers['Content-Type'] = 'application/octet-stream'
+                headers['Content-Length'] = str(len(request_body))
+                headers['Content-Range'] = f'{index}-{offset}'
 
                 index = offset
                 last = False

--- a/core/registry.py
+++ b/core/registry.py
@@ -83,7 +83,7 @@ class Registry(object):
 
             # push individual image layers
             layers = image_config["Layers"]
-            manifest_layer_info = {}
+            manifest_layer_info = []
             for layer in layers:
                 layer_digest, layer_size = self._process_layer(
                     layer, image, tmp_dir_name

--- a/core/registry.py
+++ b/core/registry.py
@@ -6,7 +6,6 @@ import hashlib
 import urllib.parse
 import time
 import threading
-import zlib
 
 import humanfriendly
 import requests

--- a/core/registry.py
+++ b/core/registry.py
@@ -255,7 +255,7 @@ class Registry:
         return upload_url
 
     def _push_layer(self, layer_path, upload_url):
-        return self._chunked_upload(layer_path, upload_url, compress=False)
+        return self._chunked_upload(layer_path, upload_url, compress=True)
 
     def _push_config(self, config_path, upload_url):
         self._chunked_upload(config_path, upload_url)

--- a/core/registry.py
+++ b/core/registry.py
@@ -152,6 +152,7 @@ class Registry(object):
             self._logger.log_and_raise(
                 'error',
                 'Failed to push manifest',
+                manifest=manifest,
                 image=image,
                 tag=tag,
                 status_code=response.status_code,
@@ -208,7 +209,6 @@ class Registry(object):
 
     def _chunked_upload(self, filepath, initial_url, gzip=False):
         content_path = os.path.abspath(filepath)
-        total_size = os.stat(filepath).st_size
 
         # for kaniko compatibility - must be real tar.gzip and not just tar
         if gzip:
@@ -218,11 +218,12 @@ class Registry(object):
                     'File is not gzipped - compressing before upload',
                     content_path=content_path,
                     new_content_path=new_content_path,
-                    total_size=total_size,
                 )
 
                 subprocess.check_call(shlex.split(f'gzip -9 {content_path}'))
                 content_path = new_content_path
+
+        total_size = os.stat(filepath).st_size
 
         total_pushed_size = 0
         length_read = 0

--- a/core/registry.py
+++ b/core/registry.py
@@ -115,7 +115,6 @@ class Registry:
                 'Pushing image config',
                 image=image,
                 config_path=config_path,
-                config_parsed=config_parsed,
             )
             push_url = self._initialize_push(image)
             digest, size = self._push_config(config_path, push_url)
@@ -129,7 +128,7 @@ class Registry:
                 image, tag, config_path, manifest_layer_info, config_info
             ).create()
 
-            self._logger.info(
+            self._logger.debug(
                 'Pushing image tag manifest',
                 image=image,
                 tag=tag,

--- a/core/registry.py
+++ b/core/registry.py
@@ -211,7 +211,7 @@ class Registry:
                     gzip_cmd = shlex.split(f'gzip -9 -f {layer_path}')
                     out = subprocess.check_output(gzip_cmd, encoding='utf-8')
                     self._logger.debug(
-                        'Finished gzip command', gzip_cmd=gzip_cmd, out=out
+                        'Successfully gzipped layer', gzip_cmd=gzip_cmd, out=out
                     )
 
                 # whether we compressed it now or beforehand, the new name has this new prefix by gzip

--- a/core/registry.py
+++ b/core/registry.py
@@ -129,7 +129,12 @@ class Registry:
             # Override tags if needed: from --replace-tags-match and --replace-tags-target
             tag = self._replace_tag(image, tag)
 
-            self._logger.info('Pushing image tag manifest', image=image, tag=tag, image_manifest=image_manifest)
+            self._logger.info(
+                'Pushing image tag manifest',
+                image=image,
+                tag=tag,
+                image_manifest=image_manifest,
+            )
             self._push_manifest(image_manifest, image, tag)
             repo_tag_elapsed = time.time() - repo_tag_start_time
             self._logger.info(

--- a/core/registry.py
+++ b/core/registry.py
@@ -34,15 +34,15 @@ class LayersLock:
 
 class Registry:
     def __init__(
-            self,
-            logger,
-            registry_url,
-            stream=False,
-            login=None,
-            password=None,
-            ssl_verify=True,
-            replace_tags_match=None,
-            replace_tags_target=None,
+        self,
+        logger,
+        registry_url,
+        stream=False,
+        login=None,
+        password=None,
+        ssl_verify=True,
+        replace_tags_match=None,
+        replace_tags_target=None,
     ):
         self._logger = logger.get_child('registry')
 
@@ -203,11 +203,17 @@ class Registry:
                 # handle symlinks
                 if os.path.islink(layer_path):
                     symlinked_path = os.path.realpath(layer_path)
-                    self._logger.debug('Found symlink layer', layer_path=layer_path, symlinked_path=symlinked_path)
+                    self._logger.debug(
+                        'Found symlink layer',
+                        layer_path=layer_path,
+                        symlinked_path=symlinked_path,
+                    )
 
                     # symlink target missing (probably compressed tar -> tar.gz)
                     compressed_symlinked_path = symlinked_path + '.gz'
-                    if not os.path.exists(symlinked_path) and os.path.exists(compressed_symlinked_path):
+                    if not os.path.exists(symlinked_path) and os.path.exists(
+                        compressed_symlinked_path
+                    ):
 
                         # fix
                         tmp_link_path = f'{layer_path}_tmplink'
@@ -215,11 +221,13 @@ class Registry:
                         os.unlink(layer_path)
                         os.rename(tmp_link_path, layer_path)
                     elif not os.path.exists(symlinked_path):
-                        self._logger.log_and_raise('error',
-                                                   'Target for symlink is missing. Cannot continue pushing',
-                                                   symlinked_path=symlinked_path,
-                                                   layer_path=layer_path,
-                                                   image=image)
+                        self._logger.log_and_raise(
+                            'error',
+                            'Target for symlink is missing. Cannot continue pushing',
+                            symlinked_path=symlinked_path,
+                            layer_path=layer_path,
+                            image=image,
+                        )
 
                 # safety - handle cases where some race or corruption may have occurred, if .tar.gz is in place, skip
                 # compression and ignore the original
@@ -243,7 +251,10 @@ class Registry:
                         cmd = shlex.split(f'ls -latr {os.path.dirname(layer_path)}')
                         out = subprocess.check_output(cmd, encoding='utf-8')
                         self._logger.warn(
-                            'Finished ls command', cmd=cmd, out=out, orig_exc=exc,
+                            'Finished ls command',
+                            cmd=cmd,
+                            out=out,
+                            orig_exc=exc,
                         )
                         raise
 

--- a/core/registry.py
+++ b/core/registry.py
@@ -210,21 +210,19 @@ class Registry(object):
     def _chunked_upload(self, filepath, initial_url, gzip=False):
         content_path = os.path.abspath(filepath)
 
-        # for kaniko compatibility - must be real tar.gzip and not just tar
+        # for Kaniko compatibility - must be real tar.gzip and not just tar
         if gzip and os.path.splitext(filepath)[1] == '.tar':
-            new_content_path = content_path + '.gz'
             self._logger.debug(
                 'File is not gzipped - compressing before upload',
                 content_path=content_path,
-                new_content_path=new_content_path,
             )
 
             gzip_cmd = shlex.split(f'gzip -9 {content_path}')
-            out = subprocess.check_call(gzip_cmd)
-            self._logger.debug('Finished gzipping', gzip_cmd=gzip_cmd, out=out)
-            content_path = new_content_path
+            out = subprocess.check_output(gzip_cmd, encoding='utf-8')
+            self._logger.debug('Finished gzip command', gzip_cmd=gzip_cmd, out=out)
+            content_path = content_path + '.gz'
 
-        total_size = os.stat(filepath).st_size
+        total_size = os.stat(content_path).st_size
 
         total_pushed_size = 0
         length_read = 0

--- a/core/registry.py
+++ b/core/registry.py
@@ -187,11 +187,12 @@ class Registry:
         try:
 
             if layer_key in self._layers_info:
+                layer_info = self._layers_info[layer_key]
                 self._logger.info(
                     'Layer already pushed, skipping',
-                    layer_info=self._layers_info[layer_key],
+                    layer_info=layer_info,
                 )
-                return self._layers_info['digest'], self._layers_info['size']
+                return layer_info['digest'], layer_info['size']
 
             layer_path = os.path.abspath(os.path.join(tmp_dir_name, layer))
 

--- a/core/registry.py
+++ b/core/registry.py
@@ -238,9 +238,9 @@ class Registry(object):
                 offset = index + len(chunk)
 
                 if gzip:
-                    headers['Content-Type'] = 'application/gzip'
-                else:
-                    headers['Content-Type'] = 'application/octet-stream'
+                    headers['Content-Encoding'] = 'gzip'
+
+                headers['Content-Type'] = 'application/octet-stream'
                 headers['Content-Length'] = str(len(chunk))
                 headers['Content-Range'] = f'{index}-{offset}'
                 index = offset

--- a/core/registry.py
+++ b/core/registry.py
@@ -207,7 +207,8 @@ class Registry:
                         layer_path=layer_path,
                     )
 
-                    gzip_cmd = shlex.split(f'gzip -9 {layer_path}')
+                    # use -f to avoid "Too many levels of symbolic links" failures
+                    gzip_cmd = shlex.split(f'gzip -9 -f {layer_path}')
                     out = subprocess.check_output(gzip_cmd, encoding='utf-8')
                     self._logger.debug(
                         'Finished gzip command', gzip_cmd=gzip_cmd, out=out

--- a/core/registry.py
+++ b/core/registry.py
@@ -93,7 +93,7 @@ class Registry:
             repo_tag_start_time = time.time()
             image, tag = self._parse_image_tag(repo)
             self._logger.info(
-                'Pushing image repo and tag',
+                'Processing image repo and tag',
                 image=image,
                 tag=tag,
                 tmp_dir_name=tmp_dir_name,

--- a/core/registry.py
+++ b/core/registry.py
@@ -6,6 +6,7 @@ import hashlib
 import urllib.parse
 import time
 import threading
+import shlex
 import subprocess
 
 import humanfriendly
@@ -212,11 +213,13 @@ class Registry(object):
         # for kaniko compatibility - must be real tar.gzip and not just tar
         if gzip:
             if os.path.splitext(filepath)[1] == '.tar':
-                self._logger.debug('Failed is not gzipped and gzipped asked - compressing before upload',
-                                   filepath=filepath,
-                                   total_size=total_size)
+                self._logger.debug(
+                    'File is not gzipped - compressing before upload',
+                    filepath=filepath,
+                    total_size=total_size,
+                )
 
-                subprocess.check_call(f'gzip -9 {content_path}')
+                subprocess.check_call(shlex.split(f'gzip -9 {content_path}'))
                 content_path = content_path + '.gz'
 
         total_pushed_size = 0

--- a/dockerregistrypusher.py
+++ b/dockerregistrypusher.py
@@ -72,7 +72,7 @@ def register_arguments(parser):
         'archive_path',
         metavar='ARCHIVE_PATH',
         type=str,
-        help='The url of the target registry to push to',
+        help='The path of the images archive to push',
     )
 
     parser.add_argument(

--- a/dockerregistrypusher.py
+++ b/dockerregistrypusher.py
@@ -28,10 +28,13 @@ def run(args):
     # initialize and start processing
     processor = core.Processor(
         logger=logger,
+        tmp_dir=args.tmp_dir,
+        tmp_dir_override=args.tmp_dir_override,
         parallel=args.parallel,
         registry_url=args.registry_url,
         archive_path=args.archive_path,
         stream=args.stream,
+        gzip_layers=args.gzip_layers,
         login=args.login,
         password=args.password,
         ssl_verify=args.ssl_verify,
@@ -66,6 +69,22 @@ def register_arguments(parser):
         help='Control parallelism (threads)',
         type=int,
         default=1,
+    )
+
+    parser.add_argument(
+        '-td',
+        '--tmp-dir',
+        help='Create the temporary workspace inside this dir (optional)',
+        type=str,
+        required=False,
+    )
+
+    parser.add_argument(
+        '-tdo',
+        '--tmp-dir-override',
+        help='Use this dir as the temporary workspace (optional)',
+        type=str,
+        required=False,
     )
 
     parser.add_argument(
@@ -105,6 +124,13 @@ def register_arguments(parser):
         help='Add some streaming logging during push',
         type=bool,
         default=True,
+    )
+
+    parser.add_argument(
+        '--gzip-layers',
+        help='Gzip all layers (pre-processing) before pushing',
+        type=bool,
+        default=False,
     )
 
     parser.add_argument(

--- a/dockerregistrypusher.py
+++ b/dockerregistrypusher.py
@@ -129,7 +129,7 @@ def register_arguments(parser):
     parser.add_argument(
         '--gzip-layers',
         help='Gzip all layers (pre-processing) before pushing',
-        type=bool,
+        action='store_true',
         default=False,
     )
 

--- a/dockerregistrypusher.py
+++ b/dockerregistrypusher.py
@@ -129,8 +129,8 @@ def register_arguments(parser):
     parser.add_argument(
         '--gzip-layers',
         help='Gzip all layers (pre-processing) before pushing',
-        action='store_true',
-        default=False,
+        type=bool,
+        default=True,
     )
 
     parser.add_argument(

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,27 @@
+import hashlib
+import json
+
+
+def get_digest(filepath):
+    return "sha256:" + get_file_sha256(filepath)
+
+
+def load_json_file(filepath):
+    with open(filepath, 'r') as fh:
+        return json.loads(fh.read())
+
+
+def dump_json_file(filepath, json_contents):
+    with open(filepath, 'w') as fh:
+        json.dump(json_contents, fh)
+
+
+def get_file_sha256(filepath):
+    sha256hash = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        while True:
+            data = f.read(65536)
+            sha256hash.update(data)
+            if not data:
+                break
+    return sha256hash.hexdigest()


### PR DESCRIPTION
- Read: https://github.com/google/go-containerregistry/issues/895#issuecomment-753521526
  See diagram: https://github.com/google/go-containerregistry/blob/main/pkg/v1/tarball/README.md#structure

- This defacto saves the layers in v2 schema (while docker save tarball container a mixture of v1 and v2 in a fucked up way)